### PR TITLE
Needed route for PayPalStandard PDTHandler added.

### DIFF
--- a/src/Plugins/SmartStore.PayPal/RouteProvider.cs
+++ b/src/Plugins/SmartStore.PayPal/RouteProvider.cs
@@ -51,7 +51,12 @@ namespace SmartStore.PayPal
             )
             .DataTokens["area"] = "SmartStore.PayPal";
 
-
+            routes.MapRoute("Plugin.Payments.PayPalStandard.PDTHandler",
+                 "Plugins/PaymentPayPalStandard/PDTHandler",
+                 new { controller = "PayPalStandard", action = "PDTHandler" },
+                 new[] { "SmartStore.PayPal.Controllers" }
+            )
+            .DataTokens["area"] = "SmartStore.PayPal";
 
             //TODO: Check whether these Routes needs to stay
             //routes.MapRoute("Payments.PayPal.RedirectFromPaymentInfo",
@@ -60,13 +65,6 @@ namespace SmartStore.PayPal
             //     new[] { "SmartStore.PayPal.Controllers" }
             //)
             //.DataTokens["area"] = "SmartStore.PayPal";
-
-            //routes.MapRoute("Plugin.Payments.PayPalStandard.PDTHandler",
-            //     "Plugins/PaymentPayPalStandard/PDTHandler",
-            //     new { controller = "PaymentPayPalStandard", action = "PDTHandler" },
-            //     new[] { "SmartStore.Plugin.Payments.PayPalStandard.Controllers" }
-            //)
-            //.DataTokens["area"] = "Payments.PayPalStandard";
 
             //routes.MapRoute("Plugin.Payments.PayPalStandard.CancelOrder",
             //     "Plugins/PaymentPayPalStandard/CancelOrder",


### PR DESCRIPTION
Without this route the following site is displayed.
![sitenotfound](https://cloud.githubusercontent.com/assets/2790090/4781435/f5165ff4-5c9e-11e4-9f26-1baf67444073.PNG)

In the PayPalStandard Settings-Page the following is described.
![descriptionpaypalstandard](https://cloud.githubusercontent.com/assets/2790090/4781437/0b955096-5c9f-11e4-88a8-d0304a3ae11f.PNG)

The Handler is configured in the PayPal ReturnUrl
![paypalsettings](https://cloud.githubusercontent.com/assets/2790090/4781439/231fa04a-5c9f-11e4-807a-d3c1b6614f4e.PNG)
