### PR TITLE
Parameter of NewsItem in NewsItemController renamed to NewsItem

### DIFF
--- a/src/Presentation/SmartStore.Web/Controllers/NewsController.cs
+++ b/src/Presentation/SmartStore.Web/Controllers/NewsController.cs
@@ -232,12 +232,12 @@ namespace SmartStore.Web.Controllers
             return new RssActionResult() { Feed = feed };
         }
 
-        public ActionResult NewsItem(int id)
+        public ActionResult NewsItem(int newsItemId)
         {
             if (!_newsSettings.Enabled)
 				return HttpNotFound();
 
-            var newsItem = _newsService.GetNewsById(id);
+            var newsItem = _newsService.GetNewsById(newsItemId);
             if (newsItem == null ||
                 !newsItem.Published ||
                 (newsItem.StartDateUtc.HasValue && newsItem.StartDateUtc.Value >= DateTime.UtcNow) ||


### PR DESCRIPTION
Witout this change the following error will be displayed when navigating to the news detail page.
![newsitem_error](https://cloud.githubusercontent.com/assets/2790090/4908329/ee2bbd3e-6468-11e4-8386-55a2565664b8.PNG)
