### PR TITLE
Override of GetAdditionalHandlingFee added to PayPalStandardProvider

### DIFF
--- a/src/Plugins/SmartStore.PayPal/Providers/PayPalStandardProvider.cs
+++ b/src/Plugins/SmartStore.PayPal/Providers/PayPalStandardProvider.cs
@@ -297,6 +297,18 @@ namespace SmartStore.PayPal
 			_httpContext.Response.Redirect(builder.ToString());
 		}
 
+        /// <summary>
+        /// Gets additional handling fee
+        /// </summary>
+        /// <param name="cart">Shoping cart</param>
+        /// <returns>Additional handling fee</returns>
+        public override decimal GetAdditionalHandlingFee(IList<OrganizedShoppingCartItem> cart)
+        {
+            var result = this.CalculateAdditionalFee(_orderTotalCalculationService, cart,
+                _paypalStandardSettings.AdditionalFee, _paypalStandardSettings.AdditionalFeePercentage);
+            return result;
+        }
+
 		/// <summary>
 		/// Gets a value indicating whether customers can complete a payment after order is placed but not completed (for redirection payment methods)
 		/// </summary>


### PR DESCRIPTION
Without this Method-Override the HandlingFee for PayPalStandard is
always 0 and no Fee will be displayed and added to Total

![49f78968-5e29-11e4-8e0f-9902fa8b6bf1](https://cloud.githubusercontent.com/assets/2790090/5365302/0b5760aa-7feb-11e4-90a2-0720918e5ce1.png)
