### PR TITLE
Fixed wrong "CustomerNumber" Validation (on Update / Create)

### DIFF
--- a/src/Libraries/SmartStore.Services/Customers/CustomerService.cs
+++ b/src/Libraries/SmartStore.Services/Customers/CustomerService.cs
@@ -130,7 +130,7 @@ namespace SmartStore.Services.Customers
 
             if (q.CustomerNumber.HasValue())
             {
-                query = query.Where(c => c.CustomerNumber.Contains(q.CustomerNumber));
+                query = query.Where(c => c.CustomerNumber == q.CustomerNumber);
             }
 
             if (q.AffiliateId.GetValueOrDefault() > 0)


### PR DESCRIPTION
CustomerNumber should check for "equality" instead of "contains". Otherwise, it is not possible to create an account with a CustomerNumber "123" if another account already has "1234" as CustomerNumber.